### PR TITLE
Add KoreanBuilds to external sources

### DIFF
--- a/plugins/koreanbuilds.js
+++ b/plugins/koreanbuilds.js
@@ -1,0 +1,150 @@
+var request = require('request');
+var cheerio = require('cheerio');
+var Store = require('electron-store');
+var store = new Store();
+
+var url = "http://koreanbuilds.net";
+
+var stylesMap = {
+	"8000":8000,
+	"8100":8100,
+	"8200":8200,
+	"8300":8400,
+	"8400":8300
+};
+
+function extractPage(html, champObj, champion, role, rec, callback, pageType) {
+	var $ = cheerio.load(html);
+
+	var pages = [];
+	var runecount = -1;
+	var slots = $("div[class^=perk-itm]");
+
+
+	$("img[src^='//statics.koreanbuilds.net/perks/']", slots).each(function(index) {
+		if(index % 8 == 0) {
+			pages.push({
+				"name": champion + " " + role + " BC "+ $('#circle-big').text(),
+				"primaryStyleId": -1,
+				"selectedPerkIds": [0, 0, 0, 0, 0, 0],
+				"subStyleId": -1,
+				"bookmark": {
+					"src": url + "/champion/" + champion + "/" + role + "/" + champObj.version.replace(/\.(?:[0-9]*)$/, '') + '/-1',
+					"meta": {
+						"pageType": Math.floor(index / 6),
+						"champion": champion
+					},
+					"remote": { "name": plugin.name, "id": plugin.id }
+				}
+			})
+		}
+		var rune = $(this).attr("src");
+		rune = rune.replace("//statics.koreanbuilds.net/perks/", "");
+		rune = rune.replace(".png", "");
+		var primary = $('#reforged-primary .perk-img-c').attr("src");
+		primary = primary.replace("//statics.koreanbuilds.net/perk-types/", "");
+		primary = primary.replace(".png", "");
+		var secondary = $('#reforged-secondary .perk-img-c').attr("src");
+		secondary = secondary.replace("//statics.koreanbuilds.net/perk-types/", "");
+		secondary = secondary.replace(".png", "");
+		if(index % 6 == 0) {
+			pages[pages.length - 1].primaryStyleId = stylesMap[primary];
+			pages[pages.length - 1].subStyleId = stylesMap[secondary];
+		}
+		pages[pages.length - 1].selectedPerkIds[index] = rune;
+	});
+
+	if(rec) {
+		var reqCount = 0;
+		var summs = [];
+		$('#summSel option').each(function(index) {
+			if(index != 0)
+				summs.push($(this).val())
+		})
+		console.log("IF REC TRUE")
+		console.log("summs length", summs.length)
+		if(summs.length == 0) return callback(pages);
+		summs.forEach(function(value) {
+			console.log(url + "/champion/" + champion + "/" + role + "/" + champObj.version.replace(/\.(?:[0-9]*)$/, '') + '/'+ value)
+			request.get(url + "/champion/" + champion + "/" + role + "/" + champObj.version.replace(/\.(?:[0-9]*)$/, '') + '/' + value, (error, response, _html) => {
+				if(!error && response.statusCode == 200) {
+					var newPages = extractPage(_html, champObj, champion, role, false);
+					pages = pages.concat(newPages);
+					console.log("newPages", newPages)
+					if(++reqCount == summs.length) callback(pages);
+				}
+			});
+		});
+	}
+	var regex = /(?:\d{0,3}(\.\d{1,2})? *%?)$/
+	pages.sort((a, b) => {
+		var percentA = parseFloat(a.name.match(regex)[0]);
+		var percentB = parseFloat(b.name.match(regex)[0]);
+		return percentB - percentA;
+	})
+	return ((typeof pageType !== "undefined") ? pages[pageType] : pages);
+}
+
+function _getPages(champion, callback) {
+	var res = {pages: {}};
+
+	var champ = store.get("championsInfo")[champion]
+	var champId = champ.key;
+	request.get(url + "/roles?championid="+ champId, (error, response, html) => {
+		if(!error && response.statusCode == 200) {
+			var $ = cheerio.load(html);
+			var rolesExtracted = $.root().text().split('\n').filter((value) => value != '');
+			var roles = rolesExtracted.map((s) => { return String.prototype.trim.apply(s) })
+			if(!roles.length || roles.length == 0){
+				console.log(`No builds found for ${champion}.`)
+				callback(res)
+			} else {
+				roles.forEach((role) => {
+					var champUrl = url + "/champion/" + champion + "/" + role + "/" + champ.version.replace(/\.(?:[0-9]*)$/, '') + '/-1';
+					request.get(champUrl, (error, response, html) => {
+						if(!error && response.statusCode == 200) {
+							extractPage(html, champ, champion, role, true, (pages) => {
+								pages.forEach((page) => {
+									res.pages[page.name] = page;
+								});
+								console.log(res)
+								callback(res);
+							});
+						}
+						else {
+							throw Error("rune page not loaded");
+						}
+					});
+				})
+			}
+		}
+		else {
+			throw Error("roles page not loaded");
+		}
+	});
+	
+}
+
+var plugin = {
+	id: "koreanbuilds",
+	name: "Korean Builds",
+	active: true,
+	bookmarks: true,
+
+	getPages(champion, callback) {
+		_getPages(champion, callback);
+	},
+
+	syncBookmark(bookmark, callback) {
+		request.get(bookmark.src, (error, response, html) => {
+			if(!error && response.statusCode == 200) {
+				callback(exctractPage(html, bookmark.meta.champion, false, null, bookmark.meta.pageType));
+			}
+			else {
+				throw Error("rune page not loaded");
+			}
+		});
+	}
+}
+
+module.exports = { plugin };

--- a/src/app.js
+++ b/src/app.js
@@ -23,10 +23,11 @@ request('https://ddragon.leagueoflegends.com/api/versions.json', function (error
 });
 
 freezer.on('version:set', (ver) => {
-	request('http://ddragon.leagueoflegends.com/cdn/'+ver+'/data/en_US/champion.json', function(error, response, data) {
+	request(`http://ddragon.leagueoflegends.com/cdn/${ver}/data/en_US/champion.json`, function(error, response, data) {
 		if(!error && response && response.statusCode == 200){
 			store.set('championsInfo', JSON.parse(data).data);
 		}
+		else throw Error("Couldn't get champion info from DDragon API");
 	});
 });
 

--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,14 @@ request('https://ddragon.leagueoflegends.com/api/versions.json', function (error
 	else throw Error("Couldn't get ddragon api version");
 });
 
+freezer.on('version:set', (ver) => {
+	request('http://ddragon.leagueoflegends.com/cdn/'+ver+'/data/en_US/champion.json', function(error, response, data) {
+		if(!error && response && response.statusCode == 200){
+			store.set('championsInfo', JSON.parse(data).data);
+		}
+	});
+});
+
 freezer.on('api:connected', () => {
 	api.get("/lol-login/v1/session").then((res) => {
 		if(!res) {


### PR DESCRIPTION
Hey !
I added a KoreanBuilds plugin but i had to make some changes to the core js.
On KoreanBuilds, some champs are played on different roles, and to know which roles are played, you have an API endpoint, which is [this one (I've put Ekko's ID as an example)](https://koreanbuilds.net/roles?championid=245). So as you can see, it's played in top, jungle, and mid. So if you noticed it requires the champion ID, and if I didn't miss anything, we only have access to the champion name. So I added an extra object to the store, called championsInfo, which is created when calling the DDragon API.
See d0faaccb90e3e47180c38486d3a0432e0431f070 for how I did it.

Anyway, when building the plugin, I noticed that the Runes Path map was wrong? Or maybe KoreanBuild's map is. But basically, 8300 is the Resolve path, and 8400 is the Inspiration path. So i made a custom map to remap things and now it's okay:

![9i985uelzm0giegd](https://user-images.githubusercontent.com/2880365/36731909-7283b528-1bcc-11e8-9c16-f6399126b9fe.png)

Builds are sorted by Build Confidence, so the most "confident" is first.

If you have any question or anything you want me to change, feel free.