### PR TITLE
fix movable splashscreen

### DIFF
--- a/splashscreen.html
+++ b/splashscreen.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 
-    <img src="img/logo.png" alt="Logo">
+    <img draggable="false" src="img/logo.png" alt="Logo">
 
 </body>
 </html>


### PR DESCRIPTION
You were able to move the splashscreen image around making it be visible even after it should have dissappeared.